### PR TITLE
fix: [Android] Use delegate Application ctor

### DIFF
--- a/src/GettingStarted-01/BugTracker/BugTracker.Droid/Main.cs
+++ b/src/GettingStarted-01/BugTracker/BugTracker.Droid/Main.cs
@@ -23,7 +23,7 @@ namespace BugTracker.Droid
     public class Application : Windows.UI.Xaml.NativeApplication
     {
         public Application(IntPtr javaReference, JniHandleOwnership transfer)
-            : base(new App(), javaReference, transfer)
+            : base(() => new App(), javaReference, transfer)
         {
             ConfigureUniversalImageLoader();
         }


### PR DESCRIPTION
Ensures Android head will build properly when updated to latest version of Uno.